### PR TITLE
chore: quality review fixes + maintenance auto-close

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -48,3 +48,47 @@ jobs:
                 `---\n_Opened automatically by the Maintenance workflow._`,
               labels: ['maintenance'],
             });
+
+  close-issue-on-success:
+    needs: ci
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // Close any open maintenance issues — the most recent CI run
+            // proves the underlying problem is resolved. Without this job
+            // the issues opened by `open-issue-on-failure` linger forever
+            // and the repo looks broken to outside visitors even after the
+            // fix lands.
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'maintenance',
+            });
+            if (open.data.length === 0) {
+              console.log('No open maintenance issues to close.');
+              return;
+            }
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Maintenance CI is green again — closing automatically.\n\n**Run:** ${run.data.html_url}`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+              console.log(`Closed issue #${issue.number}`);
+            }


### PR DESCRIPTION
## Summary
Closes review.md P0 ("maintenance issue auto-close 부재") plus two earlier quality fixes that were already on this branch:

- **ci: close maintenance issue when CI is green** — the `maintenance.yml` workflow had an `open-issue-on-failure` job but no counterpart to close the issue after the underlying problem got fixed. This PR adds a `close-issue-on-success` job that lists every open issue labeled `maintenance`, leaves a comment linking back to the resolving run, and closes them. Future regressions reopen a fresh issue, so no signal is lost.
- **npm audit fix** and **WXT/Plasmo URL + setup checklist corrections** — the two earlier commits on this branch.

## Test plan
- [ ] Merge this PR → the weekly maintenance workflow fires → with a green CI, any lingering `maintenance`-labeled issues get closed automatically.
- [ ] Break the build intentionally in a throwaway branch → `open-issue-on-failure` still fires; fixing it closes the issue on the next green run.