### PR TITLE
Fix: correct docs path references in deploy workflows

### DIFF
--- a/.github/workflows/cd-fly.yml
+++ b/.github/workflows/cd-fly.yml
@@ -39,7 +39,7 @@ jobs:
           HAS_FLY_TOKEN: ${{ secrets.FLY_API_TOKEN != '' }}
         run: |
           if [ "$HAS_FLY_TOKEN" != "true" ]; then
-            echo "::error::Missing required secret: FLY_API_TOKEN — See docs/FLY_DEPLOY.md"
+            echo "::error::Missing required secret: FLY_API_TOKEN — See docs/DEPLOY_GUIDE.md"
             exit 1
           fi
 

--- a/.github/workflows/cd-railway.yml
+++ b/.github/workflows/cd-railway.yml
@@ -43,7 +43,7 @@ jobs:
           if [ "$HAS_RAILWAY_TOKEN" != "true" ]; then MISSING="$MISSING RAILWAY_TOKEN"; fi
           if [ "$HAS_SERVICE_ID" != "true" ]; then MISSING="$MISSING RAILWAY_SERVICE_ID"; fi
           if [ -n "$MISSING" ]; then
-            echo "::error::Missing required secrets:$MISSING — See docs/RAILWAY_DEPLOY.md"
+            echo "::error::Missing required secrets:$MISSING — See docs/DEPLOY_GUIDE.md"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Fixes docs path references in `.github/workflows/cd-railway.yml` and `.github/workflows/cd-fly.yml`
- Keeps workflow output aligned with actual doc locations

## Test plan
- [x] Workflow YAML syntax valid
- [ ] CI passes (workflow file changes may not trigger CI)