### PR TITLE
feat: add autocomplete slash command example

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -52,7 +52,8 @@ npm run dev
 │   ├── config.js                 # 환경변수 설정 로더
 │   ├── commands/                 # 슬래시 커맨드 (자동 로드)
 │   │   ├── ping.js               # /ping — 지연시간 확인
-│   │   └── help.js               # /help — 커맨드 목록
+│   │   ├── help.js               # /help — 커맨드 목록
+│   │   └── search.js             # /search — 자동완성 예제
 │   └── events/                   # 이벤트 핸들러 (자동 로드)
 │       ├── ready.js              # 봇 준비 완료
 │       └── interactionCreate.js  # 커맨드 라우터
@@ -84,7 +85,7 @@ npm run dev
 - **Docker** — 프로덕션 Dockerfile + 핫 리로드 개발용 compose
 - **버전 관리** — `npm run version:patch/minor/major`로 `package.json` 버전 업
 - **개발 모드** — `npm run dev`로 `node --watch` 라이브 리로드
-- **스타터 코드** — `/ping` + `/help` 커맨드, 모듈형 이벤트 핸들러
+- **스타터 코드** — `/ping`, `/help`, `/search` (autocomplete 예제) 커맨드, 모듈형 이벤트 핸들러
 - **배포 가이드** — Discord, Railway, Fly.io 설정 단계별 문서
 - **템플릿 셋업** — 첫 사용 시 설정 체크리스트 이슈 자동 생성
 
@@ -189,6 +190,23 @@ module.exports = {
 그리고 등록: `npm run deploy-commands`
 
 커맨드는 자동 로드됩니다 — 다른 파일을 수정할 필요 없습니다.
+
+### 자동완성 (Autocomplete)
+
+자동완성 패턴은 `src/commands/search.js`를 참고하세요. 옵션에 `.setAutocomplete(true)`를 붙이고, `execute`와 함께 `autocomplete(interaction)` 함수를 export하면 됩니다:
+
+```js
+async autocomplete(interaction) {
+  const focused = interaction.options.getFocused().toLowerCase();
+  const matches = CHOICES
+    .filter((c) => c.toLowerCase().includes(focused))
+    .slice(0, 25) // Discord은 응답을 최대 25개로 제한
+    .map((c) => ({ name: c, value: c }));
+  await interaction.respond(matches);
+}
+```
+
+`src/events/interactionCreate.js`의 디스패처가 `isAutocomplete()` 인터랙션을 자동으로 이 핸들러로 라우팅합니다.
 
 ## Sapphire / Akairo 대신 이걸 쓰는 이유
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ npm run dev
 │   ├── config.js                 # Environment config loader
 │   ├── commands/                 # Slash commands (auto-loaded)
 │   │   ├── ping.js               # /ping — check latency
-│   │   └── help.js               # /help — list commands
+│   │   ├── help.js               # /help — list commands
+│   │   └── search.js             # /search — autocomplete example
 │   └── events/                   # Event handlers (auto-loaded)
 │       ├── ready.js              # Bot ready
 │       └── interactionCreate.js  # Command router
@@ -84,7 +85,7 @@ npm run dev
 - **Docker** — Production Dockerfile + dev compose with hot reload
 - **Version management** — `npm run version:patch/minor/major` to bump `package.json`
 - **Dev mode** — `npm run dev` for live reload with `node --watch`
-- **Starter code** — `/ping` + `/help` commands, modular event handlers
+- **Starter code** — `/ping`, `/help`, and `/search` (autocomplete pattern) commands, modular event handlers
 - **Deploy guides** — Step-by-step docs for Discord, Railway, and Fly.io setup
 - **Template setup** — Auto-creates setup checklist issue on first use
 
@@ -189,6 +190,23 @@ module.exports = {
 Then register: `npm run deploy-commands`
 
 Commands are auto-loaded — no need to edit any other file.
+
+### Autocomplete
+
+See `src/commands/search.js` for the autocomplete pattern. Add `.setAutocomplete(true)` on an option and export an `autocomplete(interaction)` function alongside `execute`:
+
+```js
+async autocomplete(interaction) {
+  const focused = interaction.options.getFocused().toLowerCase();
+  const matches = CHOICES
+    .filter((c) => c.toLowerCase().includes(focused))
+    .slice(0, 25) // Discord caps responses at 25 choices
+    .map((c) => ({ name: c, value: c }));
+  await interaction.respond(matches);
+}
+```
+
+The dispatcher in `src/events/interactionCreate.js` routes `isAutocomplete()` interactions to this handler automatically.
 
 ## Why This Over Sapphire / Akairo?
 

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -1,0 +1,43 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+// Static list — replace with a DB query, API call, or cached list in your bot.
+const CHOICES = [
+  'apple',
+  'banana',
+  'cherry',
+  'docker',
+  'elasticsearch',
+  'grafana',
+  'kubernetes',
+  'postgres',
+  'redis',
+  'typescript',
+];
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('search')
+    .setDescription('Search a list with autocomplete')
+    .addStringOption((option) =>
+      option
+        .setName('query')
+        .setDescription('Start typing to see suggestions')
+        .setAutocomplete(true)
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    const query = interaction.options.getString('query');
+    await interaction.reply(`You picked: \`${query}\``);
+  },
+
+  async autocomplete(interaction) {
+    const focused = interaction.options.getFocused().toLowerCase();
+    const matches = CHOICES.filter((choice) => choice.toLowerCase().includes(focused))
+      // Discord caps autocomplete responses at 25 choices.
+      .slice(0, 25)
+      .map((choice) => ({ name: choice, value: choice }));
+
+    await interaction.respond(matches);
+  },
+};

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -9,6 +9,18 @@ setInterval(() => limiter.cleanup(), 120_000).unref();
 module.exports = {
   name: Events.InteractionCreate,
   async execute(interaction) {
+    // Autocomplete runs before the command is submitted — dispatch separately.
+    if (interaction.isAutocomplete()) {
+      const command = interaction.client.commands.get(interaction.commandName);
+      if (!command || typeof command.autocomplete !== 'function') return;
+      try {
+        await command.autocomplete(interaction);
+      } catch (error) {
+        logger.error('interactionCreate', `Autocomplete failed for ${interaction.commandName}`, { error: error.message });
+      }
+      return;
+    }
+
     if (!interaction.isChatInputCommand()) return;
 
     const command = interaction.client.commands.get(interaction.commandName);


### PR DESCRIPTION
## Summary
- Adds `/search` command demonstrating Discord.js autocomplete — users only saw trivial `/ping` + `/help` before, missing the non-obvious pattern.
- Wires up `isAutocomplete()` dispatch in `src/events/interactionCreate.js` so any command exporting `autocomplete(interaction)` just works.
- Static list (10 entries), 25-choice cap, case-insensitive filter — no DB/API needed to teach the pattern.
- Documents the pattern in both `README.md` and `README.ko.md` under "Adding Commands".

## Test plan
- [x] `npm run lint` — clean (3 pre-existing warnings unrelated to this PR)
- [x] `npm test` — 9/9 pass (new `search.js` validated by structural test)
- [ ] CI green on PR
- [ ] Manual: run `npm run deploy-commands` and try `/search` in Discord — typing shows filtered suggestions