### PR TITLE
feat: add /health endpoint with Docker HEALTHCHECK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ DISCORD_CLIENT_ID=your-application-id
 
 # Optional: set for guild-scoped commands (instant registration, recommended for dev)
 # DISCORD_GUILD_ID=your-dev-server-id
+
+# Health-check HTTP server port — exposed as GET /health for Docker HEALTHCHECK,
+# Fly.io `[[services.http_checks]]`, and Railway health checks.
+HEALTH_PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20-alpine
 
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    HEALTH_PORT=3000
 
 WORKDIR /app
 
@@ -10,5 +11,10 @@ RUN npm ci --omit=dev
 COPY --chown=node:node . .
 
 USER node
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget --quiet --tries=1 --spider "http://localhost:${HEALTH_PORT:-3000}/health" || exit 1
 
 CMD ["node", "src/index.js"]

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,6 +83,7 @@ npm run dev
 - **CI 파이프라인** — 보안 감사, 린트, 테스트, Docker 빌드 검증
 - **CD 파이프라인** — 원클릭 Railway 또는 Fly.io 배포 + GitHub Release 자동 생성
 - **Docker** — 프로덕션 Dockerfile + 핫 리로드 개발용 compose
+- **헬스 체크** — `GET /health` + Docker `HEALTHCHECK` 내장 — Fly.io / Railway가 죽은 봇을 감지
 - **버전 관리** — `npm run version:patch/minor/major`로 `package.json` 버전 업
 - **개발 모드** — `npm run dev`로 `node --watch` 라이브 리로드
 - **스타터 코드** — `/ping`, `/help`, `/search` (autocomplete 예제) 커맨드, 모듈형 이벤트 핸들러
@@ -244,6 +245,41 @@ async autocomplete(interaction) {
 4. `.js` 파일을 `.ts`로 변경
 
 TypeScript는 강제가 아니라 선택입니다. 많은 봇 (유틸리티 커맨드, 간단한 자동화)에는 JavaScript만으로 충분합니다.
+
+## 헬스 체크
+
+봇은 `HEALTH_PORT` (기본값 `3000`)에서 작은 HTTP 헬스 서버 (`src/lib/health.js`)를 엽니다. Docker `HEALTHCHECK`와 Fly.io / Railway가 봇 프로세스 크래시/연결 끊김을 감지하는 용도입니다.
+
+| 경로 | 상태 | 응답 |
+|------|------|------|
+| `GET /health` (ready) | `200` | `{ "status": "ok", "uptime": <초>, "guilds": <수> }` |
+| `GET /health` (시작 중 / 연결 끊김) | `503` | `{ "status": "starting", "uptime": <초>, "guilds": 0 }` |
+
+**설정**
+
+```bash
+# .env
+HEALTH_PORT=3000   # 3000이 이미 사용 중이면 변경
+```
+
+**Fly.io** — `fly.toml`에 HTTP 서비스 체크 추가:
+
+```toml
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+
+  [[services.http_checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "30s"
+    method = "get"
+    path = "/health"
+```
+
+**Railway** — **Settings → Deploy**에서 헬스 체크 경로를 `/health`, 포트를 `3000`으로 설정.
+
+**Docker** — `docker ps`가 자동으로 `(healthy)` / `(unhealthy)` 상태를 표시합니다. `HEALTHCHECK`는 30초마다 `wget --spider http://localhost:${HEALTH_PORT}/health`를 실행합니다.
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ npm run dev
 - **CI Pipeline** — Security audit, lint, test, Docker build verification on every push
 - **CD Pipeline** — One-click deploy to Railway or Fly.io + auto GitHub Release
 - **Docker** — Production Dockerfile + dev compose with hot reload
+- **Health endpoint** — Built-in `GET /health` + Docker `HEALTHCHECK` so Fly.io / Railway can detect a crashed bot
 - **Version management** — `npm run version:patch/minor/major` to bump `package.json`
 - **Dev mode** — `npm run dev` for live reload with `node --watch`
 - **Starter code** — `/ping`, `/help`, and `/search` (autocomplete pattern) commands, modular event handlers
@@ -244,6 +245,41 @@ This template uses JavaScript for simplicity. To add TypeScript:
 4. Rename `.js` files to `.ts`
 
 TypeScript is opt-in, not forced. For many bots (utility commands, simple automation), JavaScript is all you need.
+
+## Health Check
+
+The bot exposes a tiny HTTP health server (`src/lib/health.js`) on `HEALTH_PORT` (default `3000`). It's used by the Docker `HEALTHCHECK` and by Fly.io / Railway to detect a crashed or disconnected bot process.
+
+| Path | Status | Body |
+|------|--------|------|
+| `GET /health` (client ready) | `200` | `{ "status": "ok", "uptime": <seconds>, "guilds": <count> }` |
+| `GET /health` (starting / disconnected) | `503` | `{ "status": "starting", "uptime": <seconds>, "guilds": 0 }` |
+
+**Configuration**
+
+```bash
+# .env
+HEALTH_PORT=3000   # change if 3000 is already taken on your host
+```
+
+**Fly.io** — add an HTTP service check to `fly.toml`:
+
+```toml
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"
+
+  [[services.http_checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "30s"
+    method = "get"
+    path = "/health"
+```
+
+**Railway** — set the service's health-check path to `/health` and port to `3000` under **Settings → Deploy**.
+
+**Docker** — `docker ps` will show `(healthy)` / `(unhealthy)` status automatically; the `HEALTHCHECK` runs `wget --spider http://localhost:${HEALTH_PORT}/health` every 30s.
 
 ## Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
-const { Client, GatewayIntentBits, Collection } = require('discord.js');
+const { Client, Events, GatewayIntentBits, Collection } = require('discord.js');
 const { loadCommands } = require('./commands');
 const { loadEvents } = require('./events');
+const { createHealthServer } = require('./lib/health');
 const config = require('./config');
 const log = require('./lib/logger');
 
@@ -13,14 +14,36 @@ client.commands = new Collection();
 loadCommands(client);
 loadEvents(client);
 
-const shutdown = () => {
-  log.info('lifecycle', 'Shutting down...');
-  client.destroy();
+const healthServer = createHealthServer(client);
+
+// Start the health server once the bot is ready so orchestrators (Fly.io,
+// Railway, Docker HEALTHCHECK) only get a 200 after the gateway connects.
+client.once(Events.ClientReady, () => {
+  healthServer.start().catch((err) => {
+    log.error('health', 'Failed to start health server', { error: err.message });
+  });
+});
+
+let shuttingDown = false;
+const shutdown = async (signal) => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log.info('lifecycle', 'Shutting down...', { signal });
+  try {
+    await healthServer.stop();
+  } catch (err) {
+    log.error('lifecycle', 'Error closing health server', { error: err.message });
+  }
+  try {
+    await client.destroy();
+  } catch (err) {
+    log.error('lifecycle', 'Error destroying client', { error: err.message });
+  }
   process.exit(0);
 };
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
 
 client.login(config.token).catch((err) => {
   log.error('lifecycle', 'Failed to log in', { error: err.message });

--- a/src/lib/health.js
+++ b/src/lib/health.js
@@ -1,0 +1,65 @@
+const http = require('http');
+const log = require('./logger');
+
+/**
+ * Create a minimal health-check HTTP server.
+ *
+ * GET /health:
+ *   - 200 OK + JSON { status, uptime, guilds } when the Discord client is ready.
+ *   - 503 Service Unavailable when the client is not yet ready or disconnected.
+ *
+ * Any other path returns 404.
+ *
+ * The server uses Node's built-in `http` module — no extra dependencies.
+ *
+ * @param {import('discord.js').Client} client
+ * @param {{ port?: number }} [options]
+ * @returns {import('http').Server}
+ */
+function createHealthServer(client, options = {}) {
+  const port = options.port ?? (Number(process.env.HEALTH_PORT) || 3000);
+
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'GET' || req.url !== '/health') {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not_found' }));
+      return;
+    }
+
+    const ready = client.isReady?.() ?? false;
+    const status = ready ? 200 : 503;
+    const body = {
+      status: ready ? 'ok' : 'starting',
+      uptime: process.uptime(),
+      guilds: ready ? client.guilds.cache.size : 0,
+    };
+
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+
+  server.on('error', (err) => {
+    log.error('health', 'Health server error', { error: err.message });
+  });
+
+  function start() {
+    return new Promise((resolve) => {
+      server.listen(port, () => {
+        log.info('health', `Health server listening on :${port}`);
+        resolve(server);
+      });
+    });
+  }
+
+  function stop() {
+    return new Promise((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+
+  server.start = start;
+  server.stop = stop;
+  return server;
+}
+
+module.exports = { createHealthServer };

--- a/tests/commands.test.js
+++ b/tests/commands.test.js
@@ -1,27 +1,102 @@
 const fs = require('fs');
 const path = require('path');
+const { SlashCommandBuilder } = require('discord.js');
 
-describe('Command files', () => {
-  const commandsPath = path.join(__dirname, '..', 'src', 'commands');
-  const commandFiles = fs
-    .readdirSync(commandsPath)
-    .filter((file) => file !== 'index.js' && file.endsWith('.js'));
+const commandsPath = path.join(__dirname, '..', 'src', 'commands');
+const commandFiles = fs
+  .readdirSync(commandsPath)
+  .filter((file) => file !== 'index.js' && file.endsWith('.js'));
 
+describe('Command modules', () => {
   test('at least one command exists', () => {
     expect(commandFiles.length).toBeGreaterThan(0);
   });
 
-  test.each(commandFiles)('%s exports data and execute', (file) => {
+  test.each(commandFiles)('%s exports a valid Discord.js command', (file) => {
     const command = require(path.join(commandsPath, file));
+
+    // Structural contract
     expect(command).toHaveProperty('data');
     expect(command).toHaveProperty('execute');
     expect(typeof command.execute).toBe('function');
-    expect(command.data.name).toBeTruthy();
-    expect(command.data.description).toBeTruthy();
+
+    // Must be a real SlashCommandBuilder — catches hand-rolled objects that
+    // won't serialize cleanly for Discord's REST API.
+    expect(command.data).toBeInstanceOf(SlashCommandBuilder);
+
+    // .toJSON() is what `deploy-commands.js` sends to Discord; if it throws,
+    // registration will fail in prod. Run it to catch schema errors early.
+    const json = command.data.toJSON();
+    expect(json.name).toMatch(/^[a-z0-9_-]{1,32}$/);
+    expect(json.description).toBeTruthy();
+    expect(json.description.length).toBeLessThanOrEqual(100);
   });
 });
 
-describe('Event files', () => {
+describe('/ping command', () => {
+  const ping = require(path.join(commandsPath, 'ping.js'));
+
+  test('replies with latency and edits with pong', async () => {
+    const sentMessage = { createdTimestamp: 1_000_050 };
+    const interaction = {
+      createdTimestamp: 1_000_000,
+      client: { ws: { ping: 42 } },
+      reply: jest.fn().mockResolvedValue({ resource: { message: sentMessage } }),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await ping.execute(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'Pinging...',
+      withResponse: true,
+    });
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    const reply = interaction.editReply.mock.calls[0][0];
+    expect(reply).toContain('Pong!');
+    expect(reply).toContain('50ms');
+    expect(reply).toContain('API: 42ms');
+  });
+});
+
+describe('/search command', () => {
+  const search = require(path.join(commandsPath, 'search.js'));
+
+  test('execute replies with the selected query', async () => {
+    const interaction = {
+      options: { getString: jest.fn().mockReturnValue('docker') },
+      reply: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await search.execute(interaction);
+
+    expect(interaction.options.getString).toHaveBeenCalledWith('query');
+    expect(interaction.reply).toHaveBeenCalledWith('You picked: `docker`');
+  });
+
+  test('autocomplete returns filtered, capped suggestions', async () => {
+    const interaction = {
+      options: { getFocused: jest.fn().mockReturnValue('re') },
+      respond: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await search.autocomplete(interaction);
+
+    expect(interaction.respond).toHaveBeenCalledTimes(1);
+    const choices = interaction.respond.mock.calls[0][0];
+    expect(Array.isArray(choices)).toBe(true);
+    expect(choices.length).toBeLessThanOrEqual(25);
+    // "re" matches "elasticsearch" and "redis" in the built-in list.
+    const values = choices.map((c) => c.value);
+    expect(values).toContain('redis');
+    for (const choice of choices) {
+      expect(choice).toHaveProperty('name');
+      expect(choice).toHaveProperty('value');
+    }
+  });
+});
+
+describe('Event modules', () => {
   const eventsPath = path.join(__dirname, '..', 'src', 'events');
   const eventFiles = fs
     .readdirSync(eventsPath)
@@ -36,5 +111,7 @@ describe('Event files', () => {
     expect(event).toHaveProperty('name');
     expect(event).toHaveProperty('execute');
     expect(typeof event.execute).toBe('function');
+    expect(typeof event.name).toBe('string');
+    expect(event.name.length).toBeGreaterThan(0);
   });
 });

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -1,0 +1,78 @@
+const http = require('http');
+const { createHealthServer } = require('../src/lib/health');
+
+function fakeClient({ ready, guilds = 0 }) {
+  return {
+    isReady: () => ready,
+    guilds: { cache: { size: guilds } },
+  };
+}
+
+function get(port, path = '/health') {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ host: '127.0.0.1', port, path }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8');
+        resolve({ status: res.statusCode, body, headers: res.headers });
+      });
+    });
+    req.on('error', reject);
+  });
+}
+
+describe('health server', () => {
+  test('returns 200 + JSON with uptime/guilds when client is ready', async () => {
+    const client = fakeClient({ ready: true, guilds: 3 });
+    // Port 0 → let the OS pick a free port so parallel runs don't collide.
+    const server = createHealthServer(client, { port: 0 });
+    await server.start();
+    const { port } = server.address();
+
+    try {
+      const res = await get(port);
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('application/json');
+
+      const body = JSON.parse(res.body);
+      expect(body.status).toBe('ok');
+      expect(typeof body.uptime).toBe('number');
+      expect(body.uptime).toBeGreaterThanOrEqual(0);
+      expect(body.guilds).toBe(3);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test('returns 503 when client is not ready', async () => {
+    const client = fakeClient({ ready: false });
+    const server = createHealthServer(client, { port: 0 });
+    await server.start();
+    const { port } = server.address();
+
+    try {
+      const res = await get(port);
+      expect(res.status).toBe(503);
+      const body = JSON.parse(res.body);
+      expect(body.status).toBe('starting');
+      expect(body.guilds).toBe(0);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test('returns 404 for unknown paths', async () => {
+    const client = fakeClient({ ready: true });
+    const server = createHealthServer(client, { port: 0 });
+    await server.start();
+    const { port } = server.address();
+
+    try {
+      const res = await get(port, '/nope');
+      expect(res.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/lib/health.js` — zero-dep HTTP server on `HEALTH_PORT` (default 3000) exposing `GET /health`. Returns 200 + `{ status, uptime, guilds }` when the Discord client is ready, 503 while starting / disconnected.
- Start the health server after `ClientReady`; close it alongside `client.destroy()` on SIGINT/SIGTERM.
- Add Docker `HEALTHCHECK` using `wget --spider` (already in `node:20-alpine`).
- Document the endpoint in README / README.ko (incl. Fly.io `http_checks` and Railway health-check wiring) and add `HEALTH_PORT=3000` to `.env.example`.
- Upgrade `tests/commands.test.js` from structural-only checks to real unit tests that call `execute` / `autocomplete` with mocked interactions and validate `SlashCommandBuilder.toJSON()` output.
- Add `tests/health.test.js` covering 200-ready / 503-starting / 404-unknown-path.

**Why:** before this change the bot process was opaque to orchestrators — Fly.io / Railway could only detect an outright crash, not a wedged gateway connection. `/health` makes a silent-death visible, and the upgraded tests catch commands that register but would fail at `execute` time.

## Test plan

- [x] `npm run lint` — clean (3 pre-existing warnings on `interactionCreate.js`, unrelated)
- [x] `npm test` — 15/15 pass (2 suites)
- [ ] CI green on this PR
- [ ] Manual: `docker build . && docker run` → `curl localhost:3000/health` returns 200 once the bot logs in