### PR TITLE
feat(security): centralize interaction reply path with safeRespond

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,6 +1,7 @@
 const { Events, MessageFlags } = require('discord.js');
 const logger = require('../lib/logger');
 const { createRateLimiter } = require('../lib/rate-limiter');
+const { safeRespond } = require('../lib/safe-interaction');
 
 const limiter = createRateLimiter(5, 60_000);
 // unref so the timer never blocks process exit (e.g., in Jest)
@@ -26,28 +27,20 @@ module.exports = {
     const command = interaction.client.commands.get(interaction.commandName);
     if (!command) {
       logger.warn('interactionCreate', `Unknown command: ${interaction.commandName}`);
-      try {
-        await interaction.reply({
-          content: `Unknown command: \`${interaction.commandName}\`. It may have been removed.`,
-          flags: MessageFlags.Ephemeral,
-        });
-      } catch (_) {
-        // interaction token expired or already handled
-      }
+      await safeRespond(interaction, {
+        content: `Unknown command: \`${interaction.commandName}\`. It may have been removed.`,
+        flags: MessageFlags.Ephemeral,
+      });
       return;
     }
 
     const { limited, retryAfterMs } = limiter.check(interaction.user.id);
     if (limited) {
       logger.warn('interactionCreate', `Rate-limited user ${interaction.user.id}`);
-      try {
-        await interaction.reply({
-          content: `You're sending commands too fast. Please wait ${Math.ceil(retryAfterMs / 1000)} seconds.`,
-          flags: MessageFlags.Ephemeral,
-        });
-      } catch (_) {
-        // interaction token expired or already handled
-      }
+      await safeRespond(interaction, {
+        content: `You're sending commands too fast. Please wait ${Math.ceil(retryAfterMs / 1000)} seconds.`,
+        flags: MessageFlags.Ephemeral,
+      });
       return;
     }
 
@@ -55,16 +48,10 @@ module.exports = {
       await command.execute(interaction);
     } catch (error) {
       logger.error('interactionCreate', `Error executing ${interaction.commandName}`, { error: error.message });
-      try {
-        const reply = { content: 'Something went wrong.', flags: MessageFlags.Ephemeral };
-        if (interaction.replied || interaction.deferred) {
-          await interaction.followUp(reply);
-        } else {
-          await interaction.reply(reply);
-        }
-      } catch (_) {
-        // interaction token expired or already handled
-      }
+      await safeRespond(interaction, {
+        content: 'Something went wrong.',
+        flags: MessageFlags.Ephemeral,
+      });
     }
   },
 };

--- a/src/lib/rate-limiter.js
+++ b/src/lib/rate-limiter.js
@@ -1,5 +1,14 @@
 /**
  * Simple per-user rate limiter for bot commands.
+ *
+ * **Topology caveat:** the store is in-memory. A multi-process deploy
+ * (e.g. discord.js sharding, multiple replicas behind the same gateway,
+ * a horizontally scaled Worker pool) will not share counts and a noisy
+ * user can spam by hitting different processes. For accurate limits in
+ * those topologies, swap `store` for an external Redis (or any KV with
+ * atomic increment + TTL) — the public API of this function is shaped
+ * to make that drop-in.
+ *
  * @param {number} maxHits - Maximum allowed invocations within the window.
  * @param {number} windowMs - Time window in milliseconds.
  */

--- a/src/lib/safe-interaction.js
+++ b/src/lib/safe-interaction.js
@@ -1,0 +1,50 @@
+const { DiscordAPIError } = require('discord.js');
+const logger = require('./logger');
+
+// Discord interaction tokens expire 15 minutes after creation, but the
+// initial response window is only 3 seconds. A reply attempt after the
+// window has closed surfaces as `DiscordAPIError` with a 10062
+// "Unknown interaction" or 40060 "Already acknowledged" code.
+const TRANSIENT_API_CODES = new Set([
+  10062, // Unknown interaction
+  40060, // Interaction has already been acknowledged
+]);
+
+/**
+ * Reply to an interaction, choosing reply vs. followUp based on whether
+ * the interaction has already been answered. Swallows transient API errors
+ * (token expired, already acknowledged, rate-limited) so a failed UX reply
+ * never crashes the worker.
+ *
+ * The discord.js REST manager already retries 429 internally with
+ * Retry-After honoured. By the time a 429 reaches us it's a hard limit;
+ * we log and drop.
+ */
+async function safeRespond(interaction, payload) {
+  try {
+    if (interaction.replied || interaction.deferred) {
+      return await interaction.followUp(payload);
+    }
+    return await interaction.reply(payload);
+  } catch (error) {
+    if (error instanceof DiscordAPIError && TRANSIENT_API_CODES.has(error.code)) {
+      logger.warn('safe-interaction', 'transient API error, dropping reply', {
+        code: error.code,
+        message: error.message,
+      });
+      return null;
+    }
+    if (error?.name === 'RateLimitError' || error?.code === 429) {
+      logger.warn('safe-interaction', 'rate-limited by Discord, dropping reply', {
+        retryAfter: error.retryAfter ?? error.timeToReset ?? null,
+      });
+      return null;
+    }
+    logger.error('safe-interaction', 'Reply failed', {
+      error: error?.message ?? String(error),
+    });
+    return null;
+  }
+}
+
+module.exports = { safeRespond };


### PR DESCRIPTION
From the 2026-05-01 audit (P1.9).

## Changes
- **`lib/safe-interaction.js`** (new) — `safeRespond(interaction, payload)` chooses reply vs. followUp, classifies errors:
  - Transient API (10062 "Unknown interaction", 40060 "Already acknowledged") → log+drop
  - 429 / `RateLimitError` → log+drop (discord.js REST manager already retries 429 internally; reaching us means budget exhausted)
  - Unexpected → bubble to logger
- **`events/interactionCreate.js`** — swap 3× `catch (_) {}` blocks for `safeRespond()`. Same behavior, structured logs.
- **`lib/rate-limiter.js`** — doc comment on the in-memory limitation for sharded / multi-replica topologies; API is shaped for a Redis swap.

## Test plan
- [x] Local: 15 tests passing
- [ ] CI green