### PR TITLE
chore(security): pin gitleaks 8.30.1 with sha256 verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,16 @@ jobs:
           fetch-depth: 0
 
       - name: Scan for secrets
+        env:
+          # Bump together; checksum from
+          # https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
         run: |
-          curl -sSfL "$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
-            | grep -o 'https://[^"]*linux_x64.tar.gz')" | tar xz -C /tmp
+          set -euo pipefail
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tgz
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tgz" | sha256sum -c -
+          tar xz -C /tmp -f /tmp/gitleaks.tgz
           /tmp/gitleaks detect --source . --verbose --redact
 
       - name: Setup Node.js


### PR DESCRIPTION
From the 2026-05-01 audit (P0.3).

Every CI run was downloading whatever the GitHub releases API resolved as `gitleaks/releases/latest` at request time, no integrity check. A registry compromise or a tag-rewrite attack on `gitleaks/gitleaks` would silently swap the binary executed against our source tree.

## Change
Replace the floating `curl + grep + tar` block with a version- and SHA256-pinned download. Bumping the version forces an explicit checksum update (visible in PR review).

```yaml
GITLEAKS_VERSION: 8.30.1
GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
```

## Test plan
- [ ] CI green (gitleaks 8.30.1 download + verify + scan still passes)
