### PR TITLE
chore: P0 supply-chain + UX hardening sweep (2026-05-07 audit)

### DIFF
--- a/.github/workflows/cd-railway.yml
+++ b/.github/workflows/cd-railway.yml
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: npm install -g --ignore-scripts @railway/cli@4.6.3
 
       - name: Deploy
         run: railway up --service "$RAILWAY_SERVICE_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Check licenses
         run: npx license-checker --failOn "GPL-2.0;GPL-3.0;AGPL-3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "jest": "^30.3.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "node --watch src/index.js",
     "deploy-commands": "node scripts/deploy-commands.js",
     "lint": "eslint src/",
-    "test": "jest --verbose --passWithNoTests",
+    "test": "jest --verbose --coverage",
     "version:patch": "node scripts/bump-version.js patch",
     "version:minor": "node scripts/bump-version.js minor",
     "version:major": "node scripts/bump-version.js major"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,16 @@
     "coverageThreshold": {
       "global": {
         "statements": 50,
-        "branches": 50,
+        "branches": 35,
         "functions": 50,
-        "lines": 50
+        "lines": 55
       }
-    }
+    },
+    "coverageReporters": [
+      "text",
+      "text-summary",
+      "json-summary"
+    ]
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 50,
-        "branches": 35,
-        "functions": 50,
-        "lines": 55
+        "statements": 70,
+        "branches": 50,
+        "functions": 65,
+        "lines": 70
       }
     },
     "coverageReporters": [

--- a/src/lib/safe-interaction.js
+++ b/src/lib/safe-interaction.js
@@ -22,7 +22,15 @@ const TRANSIENT_API_CODES = new Set([
  */
 async function safeRespond(interaction, payload) {
   try {
-    if (interaction.replied || interaction.deferred) {
+    // After deferReply() the interaction is `deferred=true, replied=false`.
+    // The correct method to fill the deferred placeholder is editReply —
+    // calling followUp would create a *second* message and leave the
+    // "Bot is thinking…" placeholder dangling forever. After the first
+    // reply (or first followUp), `replied=true` and we use followUp.
+    if (interaction.deferred && !interaction.replied) {
+      return await interaction.editReply(payload);
+    }
+    if (interaction.replied) {
       return await interaction.followUp(payload);
     }
     return await interaction.reply(payload);

--- a/tests/rate-limiter.test.js
+++ b/tests/rate-limiter.test.js
@@ -1,0 +1,61 @@
+const { createRateLimiter } = require('../src/lib/rate-limiter');
+
+describe('createRateLimiter', () => {
+  test('allows up to maxHits within the window', () => {
+    const limiter = createRateLimiter(3, 60_000);
+    expect(limiter.check('u1').limited).toBe(false);
+    expect(limiter.check('u1').limited).toBe(false);
+    expect(limiter.check('u1').limited).toBe(false);
+  });
+
+  test('limits the (maxHits+1)th call and reports retryAfterMs > 0', () => {
+    const limiter = createRateLimiter(2, 60_000);
+    limiter.check('u1');
+    limiter.check('u1');
+    const result = limiter.check('u1');
+    expect(result.limited).toBe(true);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(60_000);
+  });
+
+  test('isolates per-key budgets', () => {
+    const limiter = createRateLimiter(1, 60_000);
+    expect(limiter.check('a').limited).toBe(false);
+    expect(limiter.check('a').limited).toBe(true);
+    // Different key gets a fresh window even though `a` is limited.
+    expect(limiter.check('b').limited).toBe(false);
+  });
+
+  test('resets the budget after the window elapses', () => {
+    const realNow = Date.now;
+    let now = 1_000_000;
+    Date.now = () => now;
+    try {
+      const limiter = createRateLimiter(1, 1_000);
+      expect(limiter.check('u1').limited).toBe(false);
+      expect(limiter.check('u1').limited).toBe(true);
+      now += 1_001; // step past the window
+      expect(limiter.check('u1').limited).toBe(false);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  test('cleanup removes stale entries', () => {
+    const realNow = Date.now;
+    let now = 1_000_000;
+    Date.now = () => now;
+    try {
+      const limiter = createRateLimiter(5, 1_000);
+      limiter.check('u1');
+      limiter.check('u2');
+      now += 5_000; // way past the window
+      limiter.cleanup();
+      // After cleanup, brand-new entry. Same start as `now`.
+      const fresh = limiter.check('u1');
+      expect(fresh.limited).toBe(false);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+});

--- a/tests/safe-interaction.test.js
+++ b/tests/safe-interaction.test.js
@@ -1,0 +1,69 @@
+const { DiscordAPIError } = require('discord.js');
+const { safeRespond } = require('../src/lib/safe-interaction');
+
+function fakeInteraction(state = {}) {
+  return {
+    deferred: false,
+    replied: false,
+    reply: jest.fn().mockResolvedValue('reply-result'),
+    followUp: jest.fn().mockResolvedValue('followUp-result'),
+    editReply: jest.fn().mockResolvedValue('editReply-result'),
+    ...state,
+  };
+}
+
+describe('safeRespond', () => {
+  test('uses reply when interaction is fresh', async () => {
+    const i = fakeInteraction();
+    const r = await safeRespond(i, { content: 'hi' });
+    expect(i.reply).toHaveBeenCalled();
+    expect(i.editReply).not.toHaveBeenCalled();
+    expect(i.followUp).not.toHaveBeenCalled();
+    expect(r).toBe('reply-result');
+  });
+
+  test('uses editReply for deferred-but-not-replied (was the bug — used to followUp)', async () => {
+    const i = fakeInteraction({ deferred: true, replied: false });
+    const r = await safeRespond(i, { content: 'hi' });
+    expect(i.editReply).toHaveBeenCalled();
+    expect(i.followUp).not.toHaveBeenCalled();
+    expect(r).toBe('editReply-result');
+  });
+
+  test('uses followUp once interaction is replied', async () => {
+    const i = fakeInteraction({ replied: true });
+    const r = await safeRespond(i, { content: 'hi' });
+    expect(i.followUp).toHaveBeenCalled();
+    expect(r).toBe('followUp-result');
+  });
+
+  test('swallows DiscordAPIError 10062 (Unknown interaction)', async () => {
+    const err = new DiscordAPIError({ code: 10062, message: 'Unknown' }, 10062, 404, 'POST', 'url', {});
+    const i = fakeInteraction({ reply: jest.fn().mockRejectedValue(err) });
+    const r = await safeRespond(i, { content: 'hi' });
+    expect(r).toBeNull();
+  });
+
+  test('swallows DiscordAPIError 40060 (Already acknowledged)', async () => {
+    const err = new DiscordAPIError({ code: 40060, message: 'Already' }, 40060, 400, 'POST', 'url', {});
+    const i = fakeInteraction({ reply: jest.fn().mockRejectedValue(err) });
+    const r = await safeRespond(i, { content: 'hi' });
+    expect(r).toBeNull();
+  });
+
+  test('swallows rate-limit-shaped errors', async () => {
+    const err = Object.assign(new Error('rate limited'), {
+      name: 'RateLimitError',
+      retryAfter: 1.5,
+    });
+    const i = fakeInteraction({ reply: jest.fn().mockRejectedValue(err) });
+    const r = await safeRespond(i, { content: 'hi' });
+    expect(r).toBeNull();
+  });
+
+  test('swallows unexpected errors (no rethrow)', async () => {
+    const i = fakeInteraction({ reply: jest.fn().mockRejectedValue(new Error('boom')) });
+    const r = await safeRespond(i, { content: 'hi' });
+    expect(r).toBeNull();
+  });
+});


### PR DESCRIPTION
Combines P0 fixes from the 2026-05-07 audit. Contents vary per repo (see file diffs):

**Cross-repo (Node)**
- Every `npm ci` → `npm ci --ignore-scripts` (Shai-Hulud / PackageGate primary infection vector — lifecycle scripts are the most exploited path)
- Lockfile sync where `engines.node` was stale at `>=20`

**Per-repo bug fixes (where applicable)**
- discord-bot: `safeRespond` deferred → `editReply` (was incorrectly using `followUp`, leaving ghost 'Bot is thinking…' messages)
- telegram-bot: `safeReply` non-Grammy errors swallowed (was rethrowing, contradicting the file's contract)
- electron: `autoUpdater` errors forwarded to renderer + 3-fail cache purge
- vscode-extension: `vsix` glob safety (fail explicitly if 0 or >1 matches)
- vscode-extension: CHANGELOG placeholder `[0.1.0] - YYYY-MM-DD` removed (now matches sibling scaffolds)
- cloudflare-pages: KV NaN recovery now logs + sets `X-Counter-Recovered` header
- docker-deploy: rollback-failure cleanup (move broken compose to .failed.yml)
- react-native: auth-context `exp`/`iss` validation on rehydrate
- discord/telegram: Railway CLI version-pinned to `@4.6.3` (was unpinned global `latest`)
- discord/telegram: `npm test` adds `--coverage` so the existing `coverageThreshold` is no longer inert

**Sources**
- [CISA — npm ecosystem compromise](https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem)
- [Microsoft — Shai-Hulud 2.0](https://www.microsoft.com/en-us/security/blog/2025/12/09/shai-hulud-2-0-guidance-for-detecting-investigating-and-defending-against-the-supply-chain-attack/)

## Test plan
- [ ] CI green
- [ ] Local `npm ci --ignore-scripts` succeeds in fresh clone (no native modules required for this template)