### PR TITLE
refactor: simplify pass on modernization sweep

### DIFF
--- a/.github/workflows/cd-fly.yml
+++ b/.github/workflows/cd-fly.yml
@@ -54,7 +54,6 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Create GitHub Release
-        # Pinned by SHA — third-party action. Bump via Dependabot only.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ steps.version.outputs.version }}

--- a/.github/workflows/cd-railway.yml
+++ b/.github/workflows/cd-railway.yml
@@ -57,7 +57,6 @@ jobs:
           RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}
 
       - name: Create GitHub Release
-        # Pinned by SHA — third-party action. Bump via Dependabot only.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ steps.version.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,12 +38,8 @@ a PR.
 
 ## What's out of scope
 
-- A command framework, plugin loader, or command-group DSL — see _Non-goals_.
-- Default TypeScript — the four-step opt-in stays an opt-in.
-- A bundled database / ORM / queue — bring-your-own.
-- Voice, music, moderation toolkits — slash commands + interactions only.
-
-If you're unsure whether a change is in scope, open an issue first.
+See the README's [_Non-goals_](README.md#non-goals) — those are binding here.
+If you're unsure whether a change fits, open an issue first.
 
 ## Commits + PRs
 

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 // Static list — replace with a DB query, API call, or cached list in your bot.
 const CHOICES = [
@@ -14,10 +14,9 @@ const CHOICES = [
   'typescript',
 ];
 
-// User-supplied strings interpolated into Discord markdown can break out of
-// `code spans` by including their own backticks (or use @ / # to ping channels
-// and users). The safe default is to (a) strip backticks before quoting, and
-// (b) suppress mention parsing on the response.
+// A backtick in user input breaks out of the surrounding markdown `code span`,
+// letting the rest of the message render as formatted text. Strip backticks
+// so the code span stays intact; allowedMentions handles the @-mention side.
 function safeQuote(input) {
   return String(input).replaceAll('`', '');
 }
@@ -38,9 +37,7 @@ module.exports = {
     const query = interaction.options.getString('query');
     await interaction.reply({
       content: `You picked: \`${safeQuote(query)}\``,
-      // SuppressNotifications keeps the reply silent; allowedMentions: parse: []
-      // makes any @here / @everyone / @role / @user in user input inert.
-      flags: MessageFlags.SuppressNotifications,
+      // Any @here / @everyone / @role / @user in user input becomes inert text.
       allowedMentions: { parse: [] },
     });
   },

--- a/src/index.js
+++ b/src/index.js
@@ -45,28 +45,18 @@ const shutdown = async (signal) => {
 process.on('SIGINT', () => shutdown('SIGINT'));
 process.on('SIGTERM', () => shutdown('SIGTERM'));
 
-// Without these handlers, an uncaught error or unhandled promise rejection
-// would exit the process silently — orchestrators see only "container died,"
-// not the stack. Log the structured entry first, then let the default Node
-// behavior kill the process so Railway/Fly.io restarts the container.
-process.on('uncaughtException', (err, origin) => {
-  log.error('lifecycle', 'uncaughtException', {
-    error: err?.message ?? String(err),
-    stack: err?.stack,
-    origin,
+// Without these handlers an uncaught error would exit the process silently —
+// orchestrators see only "container died," not the stack.
+const fatalExit = (kind, err, extra = {}) => {
+  log.fatal('lifecycle', kind, {
+    error: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+    ...extra,
   });
   process.exit(1);
-});
+};
 
-process.on('unhandledRejection', (reason) => {
-  log.error('lifecycle', 'unhandledRejection', {
-    error: reason instanceof Error ? reason.message : String(reason),
-    stack: reason instanceof Error ? reason.stack : undefined,
-  });
-  process.exit(1);
-});
+process.on('uncaughtException', (err, origin) => fatalExit('uncaughtException', err, { origin }));
+process.on('unhandledRejection', (reason) => fatalExit('unhandledRejection', reason));
 
-client.login(config.token).catch((err) => {
-  log.error('lifecycle', 'Failed to log in', { error: err.message });
-  process.exit(1);
-});
+client.login(config.token).catch((err) => fatalExit('Failed to log in', err));

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,16 +1,21 @@
+const fs = require('node:fs');
+
 const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 const level = LEVELS[process.env.LOG_LEVEL?.toLowerCase()] ?? LEVELS.info;
 
-function log(severity, context, message, extra) {
-  if (LEVELS[severity] < level) return;
-  const entry = {
+function format(severity, context, message, extra) {
+  return JSON.stringify({
     ts: new Date().toISOString(),
     level: severity,
     ctx: context,
     msg: message,
     ...(extra && { extra }),
-  };
-  const out = JSON.stringify(entry);
+  });
+}
+
+function log(severity, context, message, extra) {
+  if (LEVELS[severity] < level) return;
+  const out = format(severity, context, message, extra);
   severity === "error" ? console.error(out) : console.log(out);
 }
 
@@ -19,4 +24,10 @@ module.exports = {
   info: (ctx, msg, extra) => log("info", ctx, msg, extra),
   warn: (ctx, msg, extra) => log("warn", ctx, msg, extra),
   error: (ctx, msg, extra) => log("error", ctx, msg, extra),
+  // fatal() bypasses the buffered console and writes synchronously to fd 2.
+  // Use it from crash handlers right before process.exit() so the line isn't
+  // dropped when stderr is a pipe (the default in container orchestrators).
+  fatal: (ctx, msg, extra) => {
+    fs.writeSync(2, format("error", ctx, msg, extra) + "\n");
+  },
 };

--- a/tests/commands.test.js
+++ b/tests/commands.test.js
@@ -62,34 +62,32 @@ describe('/ping command', () => {
 describe('/search command', () => {
   const search = require(path.join(commandsPath, 'search.js'));
 
+  const makeSearchInteraction = (query) => ({
+    options: { getString: jest.fn().mockReturnValue(query) },
+    reply: jest.fn().mockResolvedValue(undefined),
+  });
+
   test('execute replies with the selected query, mentions disabled', async () => {
-    const interaction = {
-      options: { getString: jest.fn().mockReturnValue('docker') },
-      reply: jest.fn().mockResolvedValue(undefined),
-    };
+    const interaction = makeSearchInteraction('docker');
 
     await search.execute(interaction);
 
     expect(interaction.options.getString).toHaveBeenCalledWith('query');
-    expect(interaction.reply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: 'You picked: `docker`',
-        allowedMentions: { parse: [] },
-      })
-    );
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'You picked: `docker`',
+      allowedMentions: { parse: [] },
+    });
   });
 
   test('execute strips backticks from user input to keep code span intact', async () => {
-    const interaction = {
-      options: { getString: jest.fn().mockReturnValue('evil`@everyone`payload') },
-      reply: jest.fn().mockResolvedValue(undefined),
-    };
+    const interaction = makeSearchInteraction('evil`@everyone`payload');
 
     await search.execute(interaction);
 
-    const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.content).toBe('You picked: `evil@everyonepayload`');
-    expect(payload.allowedMentions).toEqual({ parse: [] });
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'You picked: `evil@everyonepayload`',
+      allowedMentions: { parse: [] },
+    });
   });
 
   test('autocomplete returns filtered, capped suggestions', async () => {


### PR DESCRIPTION
## Summary

Cleanup pass over PR #36 based on parallel reuse/quality/efficiency reviews. Net **-10 lines** across `src/` + tests + CI configs.

### Real fixes

- **Wrong comment + redundant flag** in `src/commands/search.js`. `MessageFlags.SuppressNotifications` suppresses *push notifications*, not "keeps the reply silent." With `allowedMentions: { parse: [] }` already in place, the flag is no-op. Removed flag + the unused `MessageFlags` import.
- **Log line could be lost on crash.** `console.error` is buffered when stderr is piped (container default), so `process.exit(1)` immediately after may drop the line — undermining the stated goal of the new handlers. Added `logger.fatal()` using `fs.writeSync(2, …)` for guaranteed sync flush. All three exit-path callsites (`uncaughtException`, `unhandledRejection`, `client.login.catch`) now route through a single `fatalExit()` helper, which also unifies the inconsistent `err?.message ?? String(err)` vs `instanceof Error` idioms.
- **Test mock duplication** — extracted `makeSearchInteraction(query)` factory inside the `/search` describe block. Switched the first test from `expect.objectContaining` back to exact-shape `toHaveBeenCalledWith` so future payload additions break the test instead of silently passing.

### Nits

- Trimmed `src/index.js` preamble comment to the load-bearing WHY sentence.
- Trimmed `safeQuote` comment — the @/# mention reference was misleading.
- Dropped redundant "Pinned by SHA — third-party action" comments on `softprops/action-gh-release` (the SHA itself is the pin). Kept the trivy (hijack history) and superfly (no v2 tag) comments — those are load-bearing.
- `CONTRIBUTING.md` "What's out of scope" now links to README Non-goals instead of duplicating four bullets that would drift.

### Test plan

- [x] `npm run lint` clean
- [x] `npm test` 28/28 pass, 74.64 % statement coverage (above 70 % gate)
- [ ] CI green
- [ ] CodeQL analyze green