### PR TITLE
[codex] Fix Fly deploy setup guidance

### DIFF
--- a/docs/DEPLOY_GUIDE.md
+++ b/docs/DEPLOY_GUIDE.md
@@ -125,7 +125,7 @@ Go to your GitHub repo > **Settings** > **Secrets and variables** > **Actions** 
 ### 6. Deploy
 
 1. Bump version: `npm run version:patch`
-2. Commit and push
+2. Commit and push, including the generated `fly.toml`
 3. Go to **Actions** tab > **Deploy to Fly.io** > **Run workflow**
 
 The workflow runs CI first, then deploys to Fly.io and creates a GitHub Release.

--- a/docs/FLY_DEPLOY.md
+++ b/docs/FLY_DEPLOY.md
@@ -38,6 +38,11 @@ fly launch --no-deploy
 
 > Select **No** when asked about a database or Redis. Discord bots don't need them by default.
 
+Commit the resulting `fly.toml` before using GitHub Actions deploys. The workflow
+checks out the repository and runs `flyctl deploy --remote-only`, so the config
+must exist in git. Keep secrets out of `fly.toml`; use `fly secrets` and GitHub
+Actions secrets for tokens.
+
 ## 3. Set Secrets
 
 ```bash
@@ -91,7 +96,9 @@ The workflow will deploy and create a GitHub Release automatically.
 
 ### Bot goes offline
 - Check logs: `fly logs`
-- Make sure `fly.toml` does NOT have a `[[services]]` section (bots are workers, not web servers)
+- Keep the template's `[[services]]` health-check section unless you intentionally
+  remove the HTTP health server too. It points Fly at `/health` and keeps one
+  machine running for the persistent Discord gateway connection.
 
 ### "Out of memory"
 - Scale up: `fly scale vm shared-cpu-1x --memory 512`

--- a/fly.toml.example
+++ b/fly.toml.example
@@ -8,7 +8,9 @@
 #   5. Set the FLY_API_TOKEN secret in GitHub: `flyctl tokens create deploy`.
 #   6. Trigger the `Deploy to Fly.io` workflow from the Actions tab.
 #
-# `fly.toml` is gitignored — keep it local. This `.example` is checked in.
+# Commit the generated `fly.toml` when you use the GitHub Actions Fly deploy.
+# The file contains app routing/config only; keep tokens in Fly secrets and
+# GitHub Actions secrets, never in this file.
 
 app = "your-bot-app-name"
 primary_region = "nrt"


### PR DESCRIPTION
## What changed
- Clarifies that `fly.toml` must be committed for GitHub Actions Fly deploys.
- Aligns the Fly troubleshooting guidance with the template health-check service.

## Verification
- `git diff --check`
- Ruby YAML parse for `.github/workflows/*.yml`
- `npm test -- --runInBand`
- `npm run lint`
