### PR TITLE
Harden Discord bot starter smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Build smoke
+        run: npm run build
+
       - name: Docker build verification
         run: docker build -t discord-bot-starter:test .
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -31,6 +31,7 @@
 npx @starter-series/create my-discord-bot --template discord-bot
 cd my-discord-bot && npm install
 cp .env.example .env  # DISCORD_TOKEN + DISCORD_CLIENT_ID 입력
+npm run deploy-commands -- --dry-run
 npm run deploy-commands
 npm run dev
 ```
@@ -41,6 +42,7 @@ npm run dev
 git clone https://github.com/starter-series/discord-bot-starter my-discord-bot
 cd my-discord-bot && npm install
 cp .env.example .env
+npm run deploy-commands -- --dry-run
 npm run deploy-commands
 npm run dev
 ```
@@ -70,8 +72,9 @@ Discord Developer Portal 설정은 [docs/DISCORD_SETUP.md](docs/DISCORD_SETUP.md
 │       └── safe-interaction.js   # safeRespond() — 절대 throw하지 않는 reply/editReply/followUp 래퍼
 ├── scripts/
 │   ├── deploy-commands.js        # Discord API에 커맨드 등록
+│   ├── smoke.js                  # Discord 네트워크 없이 로컬/CI 빌드 스모크
 │   └── bump-version.js           # package.json 버전 업
-├── tests/                        # Jest — 테스트 27개, 커버리지 임계값 statements 70 %
+├── tests/                        # Jest — 커맨드/설정/런타임 테스트, 커버리지 임계값 statements 70 %
 ├── Dockerfile                    # 프로덕션 컨테이너
 ├── docker-compose.yml            # 핫 리로드 개발 환경
 ├── .github/
@@ -111,6 +114,7 @@ Discord Developer Portal 설정은 [docs/DISCORD_SETUP.md](docs/DISCORD_SETUP.md
   - SIGINT/SIGTERM이 게이트웨이 클라이언트 + 헬스 서버를 우아하게 종료.
   - `npm start` / `npm dev`에 `--enable-source-maps`로 읽기 쉬운 stack trace.
 - **CI 파이프라인** (모든 PR + main push 시) — `npm audit`, ESLint, Jest `--coverage` (statements / branches / functions / lines 모두 게이트), Docker 빌드, Trivy CRITICAL/HIGH 스캔.
+- **네트워크 없는 검증** — `npm run deploy-commands -- --dry-run`으로 Discord 인증 없이 슬래시 커맨드 payload를 직렬화하고, `npm run build`로 CI와 같은 로컬 스모크를 실행합니다.
 - **CodeQL** — push/PR + 주간 정적 분석.
 - **CD 파이프라인** — 원클릭 Railway 또는 Fly.io 배포 + GitHub Release 자동 생성. Actions 탭에서 수동 실행.
 - **Docker** — 프로덕션 `Dockerfile` + 핫 리로드 개발용 `docker-compose.yml`.
@@ -217,6 +221,12 @@ docker compose up
 # Discord에 슬래시 커맨드 등록
 npm run deploy-commands
 
+# Discord 인증/네트워크 없이 등록 payload 검증
+npm run deploy-commands -- --dry-run
+
+# CI와 같은 빌드 스모크 (commands, events, .env.example)
+npm run build
+
 # 버전 업 (package.json 자동 업데이트)
 npm run version:patch   # 1.0.0 → 1.0.1
 npm run version:minor   # 1.0.0 → 1.1.0
@@ -254,6 +264,12 @@ module.exports = {
 ```
 
 그리고 등록: `npm run deploy-commands`
+
+실제 토큰을 쓰기 전에 등록 payload를 로컬에서 검증할 수 있습니다:
+
+```bash
+npm run deploy-commands -- --dry-run
+```
 
 커맨드는 자동 로드됩니다 — 다른 파일을 수정할 필요 없습니다.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Build your bot. Push to deploy.
 npx @starter-series/create my-discord-bot --template discord-bot
 cd my-discord-bot && npm install
 cp .env.example .env  # fill in DISCORD_TOKEN + DISCORD_CLIENT_ID
+npm run deploy-commands -- --dry-run
 npm run deploy-commands
 npm run dev
 ```
@@ -41,6 +42,7 @@ npm run dev
 git clone https://github.com/starter-series/discord-bot-starter my-discord-bot
 cd my-discord-bot && npm install
 cp .env.example .env
+npm run deploy-commands -- --dry-run
 npm run deploy-commands
 npm run dev
 ```
@@ -70,8 +72,9 @@ See [docs/DISCORD_SETUP.md](docs/DISCORD_SETUP.md) for the Discord Developer Por
 │       └── safe-interaction.js   # safeRespond() — reply/editReply/followUp wrapper that never throws
 ├── scripts/
 │   ├── deploy-commands.js        # Register commands with Discord API
+│   ├── smoke.js                  # Local/CI build smoke without Discord network
 │   └── bump-version.js           # Bump package.json version
-├── tests/                        # Jest — 27 tests, coverage gated at 70 % statements
+├── tests/                        # Jest — command/config/runtime tests, coverage gated at 70 % statements
 ├── Dockerfile                    # Production container
 ├── docker-compose.yml            # Dev with hot reload
 ├── .github/
@@ -111,6 +114,7 @@ Things that exist in this repo today, backed by code on disk.
   - SIGINT/SIGTERM trigger graceful shutdown of the gateway client and health server.
   - `--enable-source-maps` on `npm start` / `npm dev` for legible stack traces.
 - **CI pipeline** (every PR + push to main) — `npm audit`, ESLint, Jest with `--coverage` (statements / branches / functions / lines all gated), Docker build, Trivy CRITICAL/HIGH scan.
+- **Network-free validation** — `npm run deploy-commands -- --dry-run` serializes every slash command without Discord credentials; `npm run build` runs the local smoke check used by CI.
 - **CodeQL** — static analysis on push/PR and weekly.
 - **CD pipelines** — one-shot Railway or Fly.io deploy + auto GitHub Release; manual trigger from the Actions tab.
 - **Docker** — production `Dockerfile` + `docker-compose.yml` for hot-reload dev.
@@ -217,6 +221,12 @@ docker compose up
 # Register slash commands with Discord
 npm run deploy-commands
 
+# Validate command registration payloads without Discord credentials/network
+npm run deploy-commands -- --dry-run
+
+# Build smoke used by CI (commands, events, .env.example)
+npm run build
+
 # Bump version (updates package.json)
 npm run version:patch   # 1.0.0 → 1.0.1
 npm run version:minor   # 1.0.0 → 1.1.0
@@ -254,6 +264,12 @@ module.exports = {
 ```
 
 Then register: `npm run deploy-commands`
+
+Before using a real token, validate the registration payload locally:
+
+```bash
+npm run deploy-commands -- --dry-run
+```
 
 Commands are auto-loaded — no need to edit any other file.
 

--- a/docs/BOT_SETUP.md
+++ b/docs/BOT_SETUP.md
@@ -52,6 +52,14 @@ Guild-scoped commands register instantly. Global commands take up to 1 hour.
 
 ## 6. Register Commands
 
+Validate command payloads locally first. This does not require a token or Discord network access:
+
+```bash
+npm run deploy-commands -- --dry-run
+```
+
+Then register commands with Discord:
+
 ```bash
 npm run deploy-commands
 ```

--- a/docs/DISCORD_SETUP.md
+++ b/docs/DISCORD_SETUP.md
@@ -69,6 +69,14 @@ On the **Bot** page, configure these settings:
 
 ## 6. Register Slash Commands
 
+Validate the command payloads locally first. This does not require a token or a Discord network call:
+
+```bash
+npm run deploy-commands -- --dry-run
+```
+
+Then register commands with Discord:
+
 ```bash
 npm run deploy-commands
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5160,9 +5160,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node --enable-source-maps src/index.js",
     "dev": "node --enable-source-maps --watch src/index.js",
     "deploy-commands": "node scripts/deploy-commands.js",
-    "lint": "eslint src/",
+    "build": "node scripts/smoke.js",
+    "lint": "eslint src/ scripts/ tests/",
     "test": "jest --verbose --coverage",
     "version:patch": "node scripts/bump-version.js patch",
     "version:minor": "node scripts/bump-version.js minor",
@@ -17,6 +18,9 @@
   "dependencies": {
     "discord.js": "^14.26.4",
     "dotenv": "^17.4.2"
+  },
+  "overrides": {
+    "undici": "6.27.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -1,45 +1,81 @@
 const { REST, Routes } = require('discord.js');
 const fs = require('fs');
 const path = require('path');
-const config = require('../src/config');
+const { loadConfig, readConfig } = require('../src/config');
 
-if (!config.clientId) {
-  console.error('Missing DISCORD_CLIENT_ID. Add it to your .env file.');
-  process.exit(1);
+function getCommandFiles(commandsPath = path.join(__dirname, '..', 'src', 'commands')) {
+  return fs
+    .readdirSync(commandsPath)
+    .filter((file) => file !== 'index.js' && file.endsWith('.js'))
+    .sort();
 }
 
-const commands = [];
-const commandsPath = path.join(__dirname, '..', 'src', 'commands');
-const commandFiles = fs
-  .readdirSync(commandsPath)
-  .filter((file) => file !== 'index.js' && file.endsWith('.js'));
+function buildCommandPayloads(commandsPath = path.join(__dirname, '..', 'src', 'commands')) {
+  const commands = [];
 
-for (const file of commandFiles) {
-  const command = require(path.join(commandsPath, file));
-  commands.push(command.data.toJSON());
-}
-
-const rest = new REST().setToken(config.token);
-
-(async () => {
-  try {
-    console.log(`Registering ${commands.length} slash commands...`);
-
-    if (config.guildId) {
-      await rest.put(
-        Routes.applicationGuildCommands(config.clientId, config.guildId),
-        { body: commands }
-      );
-      console.log('Registered guild commands (available instantly).');
-    } else {
-      await rest.put(
-        Routes.applicationCommands(config.clientId),
-        { body: commands }
-      );
-      console.log('Registered global commands (may take up to 1 hour).');
+  for (const file of getCommandFiles(commandsPath)) {
+    const command = require(path.join(commandsPath, file));
+    if (!command.data || typeof command.data.toJSON !== 'function') {
+      throw new Error(`Command ${file} must export data with toJSON()`);
     }
-  } catch (error) {
+    commands.push(command.data.toJSON());
+  }
+
+  return commands;
+}
+
+async function registerCommands(config, commands) {
+  const rest = new REST().setToken(config.token);
+  if (config.guildId) {
+    await rest.put(
+      Routes.applicationGuildCommands(config.clientId, config.guildId),
+      { body: commands }
+    );
+    return 'guild';
+  }
+
+  await rest.put(
+    Routes.applicationCommands(config.clientId),
+    { body: commands }
+  );
+  return 'global';
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  const dryRun = argv.includes('--dry-run');
+  const commands = buildCommandPayloads();
+
+  if (dryRun) {
+    const config = readConfig(env);
+    const scope = config.guildId ? 'guild' : 'global';
+    console.log(`Dry run: validated ${commands.length} slash commands for ${scope} registration.`);
+    if (!config.token || !config.clientId) {
+      console.log('Set DISCORD_TOKEN and DISCORD_CLIENT_ID before running without --dry-run.');
+    }
+    return { dryRun: true, commands };
+  }
+
+  const config = loadConfig({ env });
+  console.log(`Registering ${commands.length} slash commands...`);
+  const scope = await registerCommands(config, commands);
+  if (scope === 'guild') {
+    console.log('Registered guild commands (available instantly).');
+  } else {
+    console.log('Registered global commands (may take up to 1 hour).');
+  }
+  return { dryRun: false, scope, commands };
+}
+
+if (require.main === module) {
+  main().catch((error) => {
     console.error(error);
     process.exit(1);
-  }
-})();
+  });
+}
+
+module.exports = {
+  buildCommandPayloads,
+  getCommandFiles,
+  main,
+  registerCommands,
+};

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const path = require('path');
+const { buildCommandPayloads, getCommandFiles } = require('./deploy-commands');
+
+const root = path.join(__dirname, '..');
+
+function readEnvExampleKeys() {
+  const file = path.join(root, '.env.example');
+  const text = fs.readFileSync(file, 'utf8');
+  return new Set(
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#') && line.includes('='))
+      .map((line) => line.split('=')[0])
+  );
+}
+
+function validateEnvExample() {
+  const keys = readEnvExampleKeys();
+  const required = ['DISCORD_TOKEN', 'DISCORD_CLIENT_ID'];
+  const missing = required.filter((key) => !keys.has(key));
+  if (missing.length > 0) {
+    throw new Error(`.env.example is missing required keys: ${missing.join(', ')}`);
+  }
+}
+
+function validateEvents() {
+  const eventsPath = path.join(root, 'src', 'events');
+  const eventFiles = fs
+    .readdirSync(eventsPath)
+    .filter((file) => file !== 'index.js' && file.endsWith('.js'))
+    .sort();
+
+  for (const file of eventFiles) {
+    const event = require(path.join(eventsPath, file));
+    if (!event.name) {
+      throw new Error(`Event ${file} must export a Discord event name`);
+    }
+    if (typeof event.execute !== 'function') {
+      throw new Error(`Event ${file} must export execute()`);
+    }
+    if (event.once !== undefined && typeof event.once !== 'boolean') {
+      throw new Error(`Event ${file} once must be boolean when provided`);
+    }
+  }
+
+  return eventFiles;
+}
+
+function validateCommands() {
+  const commands = buildCommandPayloads();
+  const commandFiles = getCommandFiles();
+  if (commands.length === 0) {
+    throw new Error('At least one slash command is required');
+  }
+  return { commandFiles, commands };
+}
+
+function main() {
+  validateEnvExample();
+  const { commandFiles, commands } = validateCommands();
+  const eventFiles = validateEvents();
+  console.log(
+    `Smoke check passed: ${commands.length} commands (${commandFiles.join(', ')}) and ` +
+    `${eventFiles.length} events (${eventFiles.join(', ')}).`
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  main,
+  readEnvExampleKeys,
+  validateCommands,
+  validateEnvExample,
+  validateEvents,
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,17 +1,56 @@
-require('dotenv').config();
+require('dotenv').config({ quiet: true });
 
-if (!process.env.DISCORD_TOKEN) {
-  console.error('Missing DISCORD_TOKEN. Copy .env.example to .env and fill in your token.');
-  process.exit(1);
+const REQUIRED_KEYS = ['DISCORD_TOKEN', 'DISCORD_CLIENT_ID'];
+
+function readConfig(env = process.env) {
+  return {
+    token: env.DISCORD_TOKEN,
+    clientId: env.DISCORD_CLIENT_ID,
+    guildId: env.DISCORD_GUILD_ID,
+  };
 }
 
-if (!process.env.DISCORD_CLIENT_ID) {
-  console.error('Missing DISCORD_CLIENT_ID. Find it at https://discord.com/developers/applications');
-  process.exit(1);
+function validateConfig(config, requiredKeys = REQUIRED_KEYS) {
+  const errors = [];
+  const values = {
+    DISCORD_TOKEN: config.token,
+    DISCORD_CLIENT_ID: config.clientId,
+    DISCORD_GUILD_ID: config.guildId,
+  };
+
+  for (const key of requiredKeys) {
+    if (!values[key] || String(values[key]).trim() === '') {
+      errors.push(`Missing ${key}`);
+    }
+  }
+
+  return errors;
+}
+
+function loadConfig(options = {}) {
+  const {
+    env = process.env,
+    requiredKeys = REQUIRED_KEYS,
+    exitOnError = true,
+  } = options;
+  const config = readConfig(env);
+  const errors = validateConfig(config, requiredKeys);
+
+  if (errors.length > 0) {
+    const message = `${errors.join(', ')}. Copy .env.example to .env and fill in the required values.`;
+    if (exitOnError) {
+      console.error(message);
+      process.exit(1);
+    }
+    throw new Error(message);
+  }
+
+  return config;
 }
 
 module.exports = {
-  token: process.env.DISCORD_TOKEN,
-  clientId: process.env.DISCORD_CLIENT_ID,
-  guildId: process.env.DISCORD_GUILD_ID,
+  REQUIRED_KEYS,
+  readConfig,
+  validateConfig,
+  loadConfig,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { Client, Events, GatewayIntentBits, Collection } = require('discord.js');
 const { loadCommands } = require('./commands');
 const { loadEvents } = require('./events');
 const { createHealthServer } = require('./lib/health');
-const config = require('./config');
+const { loadConfig } = require('./config');
 const log = require('./lib/logger');
 const { errMsg, errStack } = require('./lib/err');
 
@@ -17,6 +17,8 @@ const fatalExit = (kind, err, extra = {}) => {
 
 process.on('uncaughtException', (err, origin) => fatalExit('uncaughtException', err, { origin }));
 process.on('unhandledRejection', (reason) => fatalExit('unhandledRejection', reason));
+
+const config = loadConfig();
 
 const client = new Client({
   intents: [GatewayIntentBits.Guilds],

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,33 @@
+const {
+  loadConfig,
+  readConfig,
+  validateConfig,
+} = require('../src/config');
+
+describe('config loader', () => {
+  test('readConfig maps Discord env names to runtime config keys', () => {
+    const config = readConfig({
+      DISCORD_TOKEN: 'placeholder-token',
+      DISCORD_CLIENT_ID: 'placeholder-client-id',
+      DISCORD_GUILD_ID: 'placeholder-guild-id',
+    });
+
+    expect(config).toEqual({
+      token: 'placeholder-token',
+      clientId: 'placeholder-client-id',
+      guildId: 'placeholder-guild-id',
+    });
+  });
+
+  test('validateConfig reports missing required token/client id', () => {
+    expect(validateConfig({ token: '', clientId: 'client' })).toEqual(['Missing DISCORD_TOKEN']);
+    expect(validateConfig({ token: 'token', clientId: ' ' })).toEqual(['Missing DISCORD_CLIENT_ID']);
+  });
+
+  test('loadConfig can throw instead of exiting for tests and smoke tooling', () => {
+    expect(() => loadConfig({
+      env: {},
+      exitOnError: false,
+    })).toThrow(/Missing DISCORD_TOKEN, Missing DISCORD_CLIENT_ID/);
+  });
+});

--- a/tests/deploy-commands.test.js
+++ b/tests/deploy-commands.test.js
@@ -1,0 +1,35 @@
+const {
+  buildCommandPayloads,
+  main,
+} = require('../scripts/deploy-commands');
+
+describe('deploy-commands', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('buildCommandPayloads serializes every command without Discord network access', () => {
+    const commands = buildCommandPayloads();
+    expect(commands.map((command) => command.name).sort()).toEqual(['help', 'ping', 'search']);
+    for (const command of commands) {
+      expect(command.name).toMatch(/^[a-z0-9_-]{1,32}$/);
+      expect(command.description).toBeTruthy();
+    }
+  });
+
+  test('--dry-run validates commands without requiring Discord credentials', async () => {
+    const result = await main(['--dry-run'], {});
+
+    expect(result.dryRun).toBe(true);
+    expect(result.commands).toHaveLength(3);
+    expect(logSpy.mock.calls.map((call) => call[0]).join('\n')).toContain(
+      'Set DISCORD_TOKEN and DISCORD_CLIENT_ID before running without --dry-run.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Split env loading from process exit so tests and smoke tooling can import config safely.
- Add `npm run deploy-commands -- --dry-run` for slash-command payload validation without Discord credentials or network calls.
- Add `npm run build` smoke checks for commands, events, and `.env.example`, wire it into CI, and expand lint coverage to `scripts/` and `tests/`.
- Override `undici` to `6.27.0` to close the high-severity npm audit gate while preserving `discord.js@14.26.4`.
- Update English/Korean quickstarts and setup docs to match the verified dry-run/build flow.

## README ↔ code gap table

| README claim | Verified code/command reality before fix | Fix |
|---|---|---|
| Quick Start sends users straight to `npm run deploy-commands`. | Command registration required real Discord env/network; no local dry-run existed. | Added `npm run deploy-commands -- --dry-run` and documented it before live registration. |
| CI/build posture is part of the starter. | `package.json` had no `build` script, so there was no local package-level smoke gate. | Added `npm run build` via `scripts/smoke.js` and wired it into CI. |
| Auto-loaded commands/events are starter contract. | Command payloads were only validated during tests/live registration; event shape had no smoke gate. | Smoke validates command serialization, event shape, and `.env.example`. |
| Security audit is a CI gate. | `npm audit --audit-level=high` failed on `undici` through `discord.js`. | Added npm override for `undici@6.27.0`; high gate now passes. |
| Docs claim command/test coverage. | New CLI path needed tests. | Added config and deploy dry-run Jest tests. |

## Verification

- `npm ci --ignore-scripts`
- `npm run deploy-commands -- --dry-run`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
